### PR TITLE
create tiles from openvdm instead of externaldata bucket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,6 @@ ENV VARIABLE_NAME app
 
 #ENV TITILER_MOSAIC_BACKEND s3://openvdm.dev.saildrone.com
 
-
 # expose port
 EXPOSE 3000
 # Metrics port

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY sample_data /opt/titiler/sample_data/
 ENV MODULE_NAME saildrone_custom_tiler.app.main
 ENV VARIABLE_NAME app
 
-#ENV TITILER_MOSAIC_BACKEND s3://externaldata.dev.saildrone.com
+#ENV TITILER_MOSAIC_BACKEND s3://openvdm.dev.saildrone.com
 
 # expose port
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ ENV VARIABLE_NAME app
 
 #ENV TITILER_MOSAIC_BACKEND s3://openvdm.dev.saildrone.com
 
+
 # expose port
 EXPOSE 3000
 # Metrics port

--- a/deploy/env-dev.yaml
+++ b/deploy/env-dev.yaml
@@ -10,7 +10,7 @@ app:
     - name: SD_ENV
       value: "dev"
     - name: TITILER_MOSAIC_BACKEND
-      value: "s3://externaldata.dev.saildrone.com/"
+      value: "s3://openvdm.dev.saildrone.com/"
   livenessProbe:
     httpGet:
       path: /healthz

--- a/deploy/env-prod.yaml
+++ b/deploy/env-prod.yaml
@@ -10,7 +10,7 @@ app:
     - name: SD_ENV
       value: "prod"
     - name: TITILER_MOSAIC_BACKEND
-      value: "s3://externaldata.saildrone.com/"
+      value: "s3://openvdm.saildrone.com/"
   livenessProbe:
     httpGet:
       path: /healthz

--- a/deploy/env-staging.yaml
+++ b/deploy/env-staging.yaml
@@ -10,7 +10,7 @@ app:
     - name: SD_ENV
       value: "staging"
     - name: TITILER_MOSAIC_BACKEND
-      value: "s3://externaldata.stage.saildrone.com/"
+      value: "s3://openvdm.staging.saildrone.com/"
   livenessProbe:
     httpGet:
       path: /healthz

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ aiocache==0.11.1
 aiocache[redis]==0.11.1
 ujson==4.3.0
 msgpack==1.0.3
+jinja==2.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ aiocache==0.11.1
 aiocache[redis]==0.11.1
 ujson==4.3.0
 msgpack==1.0.3
+jinja2==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ aiocache==0.11.1
 aiocache[redis]==0.11.1
 ujson==4.3.0
 msgpack==1.0.3
-jinja==2.11.2
+jinja2==2.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ aiocache==0.11.1
 aiocache[redis]==0.11.1
 ujson==4.3.0
 msgpack==1.0.3
-jinja2==2.11.2


### PR DESCRIPTION
Now that we are ingesting the geotiffs using lambdas on the openvdm bucket, we are able to create the tiles from this source data without needing to copy the tifs over to the externaldata bucket.