### PR TITLE
Df/nrt file list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,8 @@ docker_config: &docker_config
 
 branch_config: &branch_config
   production_branch: &production_branch prod
-  staging_branch: &staging_branch sd-master
+  #staging_branch: &staging_branch sd-master
+  staging_branch: &staging_branch df/nrt-file-list
   development_branch: &development_branch dev
 
 context: &context platform-k8s

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,7 @@ docker_config: &docker_config
 
 branch_config: &branch_config
   production_branch: &production_branch prod
-  #staging_branch: &staging_branch sd-master
-  staging_branch: &staging_branch df/nrt-file-list
+  staging_branch: &staging_branch sd-master
   development_branch: &development_branch dev
 
 context: &context platform-k8s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - PYTHONWARNINGS=ignore
       - VSI_CACHE=TRUE
       - VSI_CACHE_SIZE=536870912
+      - AWS_DEFAULT_REGION=us-west-2
       # GDAL VSI Config
       # https://gdal.org/user/virtual_file_systems.html#vsis3-aws-s3-files
       # https://gdal.org/user/virtual_file_systems.html#vsigs-google-cloud-storage-files

--- a/saildrone_custom_tiler/app/__init__.py
+++ b/saildrone_custom_tiler/app/__init__.py
@@ -1,3 +1,3 @@
 """cached_titiler"""
 
-#from .version import __version__  # noqa
+# from .version import __version__  # noqa

--- a/saildrone_custom_tiler/app/cache.py
+++ b/saildrone_custom_tiler/app/cache.py
@@ -29,9 +29,7 @@ class cached(aiocache.cached):
                 value.headers["X-Cache"] = "HIT"
             return value
         except Exception:
-            aiocache.logger.exception(
-                "Couldn't retrieve %s, unexpected error", key
-            )
+            aiocache.logger.exception("Couldn't retrieve %s, unexpected error", key)
 
     async def decorator(
         self,
@@ -43,18 +41,18 @@ class cached(aiocache.cached):
         **kwargs,
     ):
 
-        self.cache = aiocache.caches.get('redis_alt')
+        self.cache = aiocache.caches.get("redis_alt")
         key = self.get_cache_key(f, args, kwargs)
 
         # if requesting to overwrite or delete from cache, replace cache_action string so that
         # key is the same as one to be overwritten
         if "cache_overwrite" in key:
-          cache_read = False
-          key = key.replace("cache_overwrite", "cache_read")
+            cache_read = False
+            key = key.replace("cache_overwrite", "cache_read")
         elif "cache_delete" in key:
-          key = key.replace("cache_delete", "cache_read")
-          num_deleted = await self.cache.delete(key)
-          return 
+            key = key.replace("cache_delete", "cache_read")
+            num_deleted = await self.cache.delete(key)
+            return
 
         if cache_read:
             value = await self.get_from_cache(key)
@@ -81,24 +79,19 @@ def setup_cache():
 
     redis_host = os.getenv("REDIS_HOST", default="redis")
     redis_port = os.getenv("REDIS_PORT", default=6379)
-    
-    config: Dict[str, Any] = {
-        'default': {
-            'cache': "aiocache.SimpleMemoryCache",
-            'serializer': {
-                'class': "aiocache.serializers.StringSerializer"
-            }
-        },
-        'redis_alt': {
-            'cache': "aiocache.RedisCache",
-            'endpoint': redis_host,
-            'port': redis_port,
-            'serializer': {
-                'class': "aiocache.serializers.PickleSerializer"
-            }
-        }
-    }
 
+    config: Dict[str, Any] = {
+        "default": {
+            "cache": "aiocache.SimpleMemoryCache",
+            "serializer": {"class": "aiocache.serializers.StringSerializer"},
+        },
+        "redis_alt": {
+            "cache": "aiocache.RedisCache",
+            "endpoint": redis_host,
+            "port": redis_port,
+            "serializer": {"class": "aiocache.serializers.PickleSerializer"},
+        },
+    }
 
     if cache_settings.ttl is not None:
         config["ttl"] = cache_settings.ttl

--- a/saildrone_custom_tiler/app/main.py
+++ b/saildrone_custom_tiler/app/main.py
@@ -20,8 +20,9 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse
 
 from .cache import setup_cache
-from .routes import sd_cog
+#from .routes import sd_cog
 from .routes import sd_mosaic
+from .routes import sd_s3_proxy
 
 app = FastAPI(title="My simple app with cache")
 
@@ -32,10 +33,12 @@ add_exception_handlers(app, DEFAULT_STATUS_CODES)
 #print(cog.router)
 #app.include_router(sd_cog.router, tags=["Cloud Optimized GeoTIFF"])
 
-#print(mosaic.router)
+
+# mosaic endpoint used for Daily Product png tiles from collection of geotiffs
 app.include_router(sd_mosaic.router, prefix="/mosaic", tags=["Custom backend mosaic"])
 
-
+# s3 proxy endpoint for NRT geotiffs and json lists of desired files
+app.include_router(sd_s3_proxy.router, prefix="/nrt", tags=["s3 proxy for NRT"])
 
 
 @app.get("/healthz", description="Health Check", tags=["Health Check"])

--- a/saildrone_custom_tiler/app/main.py
+++ b/saildrone_custom_tiler/app/main.py
@@ -12,6 +12,7 @@ from titiler.application.custom import templates
 from titiler.core.errors import DEFAULT_STATUS_CODES, add_exception_handlers
 
 from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
 
 from titiler.core.dependencies import DefaultDependency
 from titiler.mosaic.factory import MosaicTilerFactory
@@ -25,6 +26,29 @@ from .routes import sd_mosaic
 from .routes import sd_s3_proxy
 
 app = FastAPI(title="My simple app with cache")
+
+
+ENV = os.getenv("SD_ENV", default="production")
+
+# open cors for testing
+if "staging" in ENV:
+    origins = [
+        "http://localhost.saildrone.com",
+        "https://localhost.saildrone.com",
+        "http://localhost",
+        "https://localhost",
+        "http://localhost:8080",
+        "http://localhost:4000",
+        "https://localhost:4000",
+    ]
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
 # Setup Cache on Startup
 app.add_event_handler("startup", setup_cache)

--- a/saildrone_custom_tiler/app/main.py
+++ b/saildrone_custom_tiler/app/main.py
@@ -21,7 +21,8 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse
 
 from .cache import setup_cache
-#from .routes import sd_cog
+
+# from .routes import sd_cog
 from .routes import sd_mosaic
 from .routes import sd_s3_proxy
 
@@ -54,8 +55,8 @@ if "staging" in ENV:
 app.add_event_handler("startup", setup_cache)
 add_exception_handlers(app, DEFAULT_STATUS_CODES)
 
-#print(cog.router)
-#app.include_router(sd_cog.router, tags=["Cloud Optimized GeoTIFF"])
+# print(cog.router)
+# app.include_router(sd_cog.router, tags=["Cloud Optimized GeoTIFF"])
 
 
 # mosaic endpoint used for Daily Product png tiles from collection of geotiffs
@@ -80,11 +81,12 @@ def landing(request: Request):
         media_type="text/html",
     )
 
-@app.get('/status')
+
+@app.get("/status")
 def status() -> dict:
     return {
         #'uptime': utils.uptime(),
-        'pid': os.getpid()
+        "pid": os.getpid()
         # 'dask_cache_size': list(dask_cache.cache.nbytes.keys()),
         #'memory_cache_size': len(backend.cache._cache),
         #'memory_cache_keys': list(backend.cache._cache.keys())

--- a/saildrone_custom_tiler/app/routes.py
+++ b/saildrone_custom_tiler/app/routes.py
@@ -359,7 +359,7 @@ class S3Proxy(BaseTilerFactory):
             
             content = response['Body'].read()
 
-            content = json.dump(content.decode())
+            content = content.decode()
 
             if OptionalHeader.x_assets in self.optional_headers:
                 headers["X-Assets"] = ",".join(data.assets)

--- a/saildrone_custom_tiler/app/routes.py
+++ b/saildrone_custom_tiler/app/routes.py
@@ -51,6 +51,7 @@ MOSAIC_BACKEND = os.getenv("TITILER_MOSAIC_BACKEND", default="")
 MOSAIC_HOST = os.getenv("TITILER_MOSAIC_HOST", default="")
 DEFAULT_REGION = os.getenv("AWS_DEFAULT_REGION", default="us-west-2")
 
+ENV = os.getenv("SD_ENV", default="production")
 
 @dataclass
 class TilerFactory(BaseTilerFactory):
@@ -364,6 +365,11 @@ class S3Proxy(BaseTilerFactory):
             if OptionalHeader.x_assets in self.optional_headers:
                 headers["X-Assets"] = ",".join(data.assets)
 
+            # open cors for testing
+            if "staging" in ENV:
+              headers["Access-Control-Allow-Credentials"] = "true"
+              headers["Access-Control-Allow-Origin"] = "*"
+
             return Response(content, media_type="application/json", headers=headers)
 
     def proxy_tif(self):
@@ -401,6 +407,11 @@ class S3Proxy(BaseTilerFactory):
 
             if OptionalHeader.x_assets in self.optional_headers:
                 headers["X-Assets"] = ",".join(data.assets)
+          
+            # open cors for testing
+            if "staging" in ENV:
+              headers["Access-Control-Allow-Credentials"] = "true"
+              headers["Access-Control-Allow-Origin"] = "*"
 
             return Response(content, media_type=MediaType.tif.value, headers=headers)
 

--- a/saildrone_custom_tiler/app/routes.py
+++ b/saildrone_custom_tiler/app/routes.py
@@ -330,7 +330,7 @@ class S3Proxy(BaseTilerFactory):
 
         @self.router.get(r"/list/{list_id}")
 
-        @cached()
+        @cached(ttl=60)
         def list(
             list_id: str = Path(..., description="name of the list in s3"),
             cache_action: str = Query(

--- a/saildrone_custom_tiler/app/routes.py
+++ b/saildrone_custom_tiler/app/routes.py
@@ -220,7 +220,7 @@ class MosaicTiler(MosaicTilerFactory):
         )
         @cached()
         def tile(
-            z: int = Path(..., ge=0, le=30, description="Mercator tiles's zoom level"),
+            z: int = Path(..., ge=0, le=14, description="Mercator tiles's zoom level"),
             x: int = Path(..., description="Mercator tiles's column"),
             y: int = Path(..., description="Mercator tiles's row"),
             tms: TileMatrixSet = Depends(self.tms_dependency),

--- a/saildrone_custom_tiler/app/routes.py
+++ b/saildrone_custom_tiler/app/routes.py
@@ -347,8 +347,10 @@ class S3Proxy(BaseTilerFactory):
 
             s3 = boto3.client('s3', **client_kwargs)
 
+            # need to remove the leading s3:// from the bucketname
+            bucket = MOSAIC_BACKEND.split('/')[2]
             content = s3.get_object(
-              Bucket=MOSAIC_BACKEND,
+              Bucket=bucket,
               Key=list_id
             )
 

--- a/saildrone_custom_tiler/app/routes.py
+++ b/saildrone_custom_tiler/app/routes.py
@@ -352,10 +352,12 @@ class S3Proxy(BaseTilerFactory):
               
             # and force the list to the right location
             key = "mosaic_maps/nrt/" + list_id
-            content = s3.get_object(
+            response = s3.get_object(
               Bucket=bucket,
               Key=key
             )
+            
+            content = response['Body'].read()
 
             content = json.dumps(content, indent=4, sort_keys=True, default=str)
 
@@ -387,10 +389,12 @@ class S3Proxy(BaseTilerFactory):
               
             # and force the list to the right location
             key = "geotiffs/nrt/" + drone_id + "/" + deployment_id + "/" + filename
-            content = s3.get_object(
+            response = s3.get_object(
               Bucket=bucket,
               Key=key
             )
+
+            content = response['Body'].read()
 
             if OptionalHeader.x_assets in self.optional_headers:
                 headers["X-Assets"] = ",".join(data.assets)

--- a/saildrone_custom_tiler/app/routes.py
+++ b/saildrone_custom_tiler/app/routes.py
@@ -357,6 +357,8 @@ class S3Proxy(BaseTilerFactory):
               Key=key
             )
 
+            content = json.dumps(content)
+
             if OptionalHeader.x_assets in self.optional_headers:
                 headers["X-Assets"] = ",".join(data.assets)
 

--- a/saildrone_custom_tiler/app/routes.py
+++ b/saildrone_custom_tiler/app/routes.py
@@ -349,9 +349,12 @@ class S3Proxy(BaseTilerFactory):
 
             # need to remove the leading s3:// from the bucketname
             bucket = MOSAIC_BACKEND.split('/')[2]
+              
+            # and force the list to the right location
+            key = "mosaic_maps/nrt/" + list_id
             content = s3.get_object(
               Bucket=bucket,
-              Key=list_id
+              Key=key
             )
 
             if OptionalHeader.x_assets in self.optional_headers:

--- a/saildrone_custom_tiler/app/routes.py
+++ b/saildrone_custom_tiler/app/routes.py
@@ -324,12 +324,12 @@ class S3Proxy(BaseTilerFactory):
     def register_routes(self):
         """This Method register routes to the router. """
 
-        self.proxy()
+        self.proxy_list()
+        self.proxy_tif()
 
-    def proxy(self):
+    def proxy_list(self):
 
         @self.router.get(r"/list/{list_id}")
-        @self.router.get(r"/geotiff/{drone_id}/{deployment_id}/{filename}")
 
         @cached(ttl=60)
         def list(
@@ -365,6 +365,9 @@ class S3Proxy(BaseTilerFactory):
                 headers["X-Assets"] = ",".join(data.assets)
 
             return Response(content, media_type="application/json", headers=headers)
+
+    def proxy_tif(self):
+        @self.router.get(r"/geotiff/{drone_id}/{deployment_id}/{filename}")
 
         # cache for 24 hrs
         @cached(ttl=86400)

--- a/saildrone_custom_tiler/app/routes.py
+++ b/saildrone_custom_tiler/app/routes.py
@@ -359,7 +359,7 @@ class S3Proxy(BaseTilerFactory):
             
             content = response['Body'].read()
 
-            content = json.dumps(content.decode(), indent=4, sort_keys=True, default=str)
+            content = json.dump(content.decode())
 
             if OptionalHeader.x_assets in self.optional_headers:
                 headers["X-Assets"] = ",".join(data.assets)

--- a/saildrone_custom_tiler/app/routes.py
+++ b/saildrone_custom_tiler/app/routes.py
@@ -359,7 +359,7 @@ class S3Proxy(BaseTilerFactory):
             
             content = response['Body'].read()
 
-            content = json.dumps(content, indent=4, sort_keys=True, default=str)
+            content = json.dumps(content.decode(), indent=4, sort_keys=True, default=str)
 
             if OptionalHeader.x_assets in self.optional_headers:
                 headers["X-Assets"] = ",".join(data.assets)

--- a/saildrone_custom_tiler/app/routes.py
+++ b/saildrone_custom_tiler/app/routes.py
@@ -357,7 +357,7 @@ class S3Proxy(BaseTilerFactory):
               Key=key
             )
 
-            content = json.dumps(content)
+            content = json.dumps(content, indent=4, sort_keys=True, default=str)
 
             if OptionalHeader.x_assets in self.optional_headers:
                 headers["X-Assets"] = ",".join(data.assets)

--- a/saildrone_custom_tiler/app/settings.py
+++ b/saildrone_custom_tiler/app/settings.py
@@ -12,8 +12,8 @@ class CacheSettings(BaseSettings):
     """Cache settings"""
 
     endpoint: Optional[str] = None
-    #ttl: int = 3600 # one hour
-    ttl: int = 2592000 # 30 days
+    # ttl: int = 3600 # one hour
+    ttl: int = 2592000  # 30 days
 
     class Config:
         """model config"""


### PR DESCRIPTION
added endpoint to pull the list of most recent NRT files for a deployment id from s3 (cached for 1 minute) and endpoint to pull NRT geotiff files (cached for 24 hrs) so that we can load the nrt files directly into google maps instead of using the mosaic map tiling for NRT.

Also:
- black formatting
- open CORS for staging