### PR TITLE
increase max zoom level from 14 to 15

### DIFF
--- a/saildrone_custom_tiler/app/routes.py
+++ b/saildrone_custom_tiler/app/routes.py
@@ -220,7 +220,7 @@ class MosaicTiler(MosaicTilerFactory):
         )
         @cached()
         def tile(
-            z: int = Path(..., ge=0, le=14, description="Mercator tiles's zoom level"),
+            z: int = Path(..., ge=0, le=15, description="Mercator tiles's zoom level"),
             x: int = Path(..., description="Mercator tiles's column"),
             y: int = Path(..., description="Mercator tiles's row"),
             tms: TileMatrixSet = Depends(self.tms_dependency),


### PR DESCRIPTION
since voyagers are mapping in shallower water with the norbit, operators are requesting to allow for one more zoom level to be able to see overlap of the data.

current max zoom is shown below at level 14, when zooming into level 15 the tiles are returned as transparent images. opening up one more zoom level for better data inspection

<img width="1572" alt="image" src="https://github.com/Saildrone/titiler/assets/22333430/0dbfbf83-d679-4634-869e-dfaeff9da956">

when new files are ingested, we clear the cache for any a affected tiles. we will also need to increase the cache clearing calls down to level 15, as per the PR below:

https://github.com/Saildrone/lambda-geotiff-update-mosaicjson/pull/18