### PR TITLE
[DT-985] Bump up to 8 replicas to speed up tiling

### DIFF
--- a/deploy/env-prod.yaml
+++ b/deploy/env-prod.yaml
@@ -5,7 +5,7 @@ awsAssumeRole:
 app:
   enabled: true
   containerPort: 3000
-  replicaCount: 4 
+  replicaCount: 8
   extraEnvs:
     - name: SD_ENV
       value: "prod"


### PR DESCRIPTION
we're running into some performance problems that manifest as lambda failures during pre-warming and general slowness as a result of increased geotiff count thanks to voyagers and shallow surveys. This is one component of making this faster.