### PR TITLE
increase resources in prod

### DIFF
--- a/deploy/env-prod.yaml
+++ b/deploy/env-prod.yaml
@@ -65,11 +65,11 @@ app:
 
   resources:
     requests:
-      cpu: 2
-      memory: 8Gi
-    limits:
       cpu: 4
-      memory: 10Gi
+      memory: 12Gi
+    limits:
+      cpu: 12
+      memory: 12Gi
 redis:
   enabled: true
   replica:


### PR DESCRIPTION
Seeing OOMKills for titiler in prod, so increasing memory and CPU resources: https://app.datadoghq.com/dashboard/579-q9e-bgw/kubernetes-resource-usage-requests-and-limits?fullscreen_end_ts=1698349157142&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1698262757142&fullscreen_widget=3733563741577210&refresh_mode=sliding&tpl_var_kube_cluster_name%5B0%5D=p-prod&tpl_var_kube_deployment%5B0%5D=titiler-saildrone-service&tpl_var_kube_namespace%5B0%5D=titiler&from_ts=1697743867953&to_ts=1698348667953&live=true